### PR TITLE
Set context to markdown only

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,3 @@
 [	// iTodo plugin
-	{ "keys": ["ctrl+shift+d"], "command": "complete" }
+	{ "keys": ["ctrl+shift+d"], "command": "complete", "context": [{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" }] }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [	// iTodo plugin
-	{ "keys": ["ctrl+shift+d"], "command": "complete" }
+	{ "keys": ["ctrl+shift+d"], "command": "complete", "context": [{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" }] }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,3 @@
 [	// iTodo plugin
-	{ "keys": ["ctrl+shift+d"], "command": "complete" }
+	{ "keys": ["ctrl+shift+d"], "command": "complete", "context": [{ "key": "selector", "operator": "equal", "operand": "text.html.markdown" }] }
 ]


### PR DESCRIPTION
Hi there, not sure if this change is desired or not. I had a problem with the `ctrl+shift+d` conflicting with other bindings, but instead of change the key binding for this plugin I simply set its context to markdown only. Seeing as how this is a markdown todo plugin it would seem to me that this change is not likely to break functionality for other users.